### PR TITLE
Fix and add browser support for tokenize function

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,8 @@
 {
-    "presets": ["env"]
+    "presets": ["env"],
+    "plugins": [
+      ["babel-plugin-inline-import", {
+        "extensions": [".tokens"]
+      }]
+    ]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -11,7 +11,8 @@
         "max-len": 2
     },
     "parserOptions": {
-       "ecmaVersion": 2017
+       "ecmaVersion": 2017,
+       "sourceType": "module"
     },
     "env": {
        "es6": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -566,6 +566,15 @@
         "babel-runtime": "^6.22.0"
       }
     },
+    "babel-plugin-inline-import": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-inline-import/-/babel-plugin-inline-import-3.0.0.tgz",
+      "integrity": "sha512-thnykl4FMb8QjMjVCuZoUmAM7r2mnTn5qJwrryCvDv6rugbJlTHZMctdjDtEgD0WBAXJOLJSGXN3loooEwx7UQ==",
+      "dev": true,
+      "requires": {
+        "require-resolve": "0.0.2"
+      }
+    },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
@@ -4047,6 +4056,12 @@
       "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
       "dev": true
     },
+    "path-extra": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/path-extra/-/path-extra-1.0.3.tgz",
+      "integrity": "sha1-fBEhiablDVlXkOetIDfkTkEMEWY=",
+      "dev": true
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -4356,6 +4371,15 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
+    },
+    "require-resolve": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/require-resolve/-/require-resolve-0.0.2.tgz",
+      "integrity": "sha1-urQQqxruLz9Vt5MXRR3TQodk5vM=",
+      "dev": true,
+      "requires": {
+        "x-path": "^0.0.2"
+      }
     },
     "resolve": {
       "version": "1.10.0",
@@ -5072,6 +5096,15 @@
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.2"
+      }
+    },
+    "x-path": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/x-path/-/x-path-0.0.2.tgz",
+      "integrity": "sha1-KU0Ha7l6dwbMBwu7Km/YxU32exI=",
+      "dev": true,
+      "requires": {
+        "path-extra": "^1.0.2"
       }
     },
     "y18n": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "./index.d.ts",
   "scripts": {
     "antlr4": "sh scripts/antlr4.sh",
-    "build": "rm -rf dist && babel --out-dir=dist src",
+    "build": "rm -rf dist && babel --out-dir=dist src --copy-files",
     "prepare": "yarn build",
     "prettier": "find src -name *.js | egrep -v '^src/(lib|antlr4)/' | xargs prettier --no-semi --single-quote --write",
     "eslint": "eslint src",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "prettier": "find src -name *.js | egrep -v '^src/(lib|antlr4)/' | xargs prettier --no-semi --single-quote --write",
     "eslint": "eslint src",
     "pretest": "eslint src && tslint-config-prettier-check ./tslint.json",
-    "test": "nyc mocha",
+    "test": "nyc mocha --require babel-register",
     "tslint": "tslint-config-prettier-check ./tslint.json"
   },
   "author": [

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "license": "MIT",
   "devDependencies": {
     "babel-cli": "^6.26.0",
+    "babel-plugin-inline-import": "^3.0.0",
     "babel-preset-env": "^1.7.0",
     "chai": "^4.2.0",
     "eslint": "^6.2.2",

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -55,7 +55,7 @@ function getTokenType(value) {
 }
 
 function getTokenTypeMap() {
-  const filePath = path.join(__dirname, '../lib/Solidity.tokens')
+  const filePath = path.join(__dirname, './lib/Solidity.tokens')
 
   return fs
     .readFileSync(filePath)

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -1,5 +1,4 @@
-const fs = require('fs')
-const path = require('path')
+import tokens from './lib/Solidity.tokens'
 
 const TYPE_TOKENS = [
   'var',
@@ -55,11 +54,7 @@ function getTokenType(value) {
 }
 
 function getTokenTypeMap() {
-  const filePath = path.join(__dirname, './lib/Solidity.tokens')
-
-  return fs
-    .readFileSync(filePath)
-    .toString('utf-8')
+  return tokens
     .split('\n')
     .map(line => rsplit(line, '='))
     .reduce((acum, [value, key]) => {


### PR DESCRIPTION
This PR makes two changes:

- Fix an issue with the tokenize function (the necessary files weren't being copied when the build was done)
- Make the tokenize function work in the browser. Before this, the `Solidity.tokens` was read on runtime using the `fs` module. I added a babel plugin to inline it in the necessary module.

(This PR does pretty much the same as https://github.com/federicobond/solidity-parser-antlr/pull/100, but the commits are different because they come from a different branch. I don't know if this might cause merge conflicts with upstream in the future.)