### PR TITLE
Add tests for handling override keyword

### DIFF
--- a/src/ASTBuilder.js
+++ b/src/ASTBuilder.js
@@ -278,6 +278,14 @@ const transformAST = {
         break
     }
 
+    let override
+    const overrideSpecifier = ctx.modifierList().overrideSpecifier()
+    if (overrideSpecifier.length === 0) {
+      override = null
+    } else {
+      override = this.visit(overrideSpecifier[0].userDefinedTypeName())
+    }
+
     return {
       name,
       parameters,
@@ -285,6 +293,7 @@ const transformAST = {
       body: block,
       visibility,
       modifiers,
+      override,
       isConstructor,
       isReceiveEther,
       isFallback,

--- a/test/ast.js
+++ b/test/ast.js
@@ -163,6 +163,7 @@ describe('AST', () => {
       },
       "visibility": "public",
       "modifiers": [],
+      "override": null,
       "isConstructor": true,
       "isFallback": false,
       "isReceiveEther": false,
@@ -184,6 +185,7 @@ describe('AST', () => {
       },
       "visibility": "external",
       "modifiers": [],
+      "override": null,
       "isConstructor": false,
       "isFallback": true,
       "isReceiveEther": false,
@@ -205,6 +207,7 @@ describe('AST', () => {
       },
       "visibility": "external",
       "modifiers": [],
+      "override": null,
       "isConstructor": false,
       "isFallback": true,
       "isReceiveEther": false,
@@ -250,6 +253,7 @@ describe('AST', () => {
       },
       "visibility": "external",
       "modifiers": [],
+      "override": null,
       "isConstructor": false,
       "isFallback": false,
       "isReceiveEther": true,
@@ -286,6 +290,81 @@ describe('AST', () => {
       'Receive Ether functions cannot have return parameters');
   })
 
+  it('FunctionDefinition with override', () => {
+    var ast = parseNode("function foo() public override {}")
+    assert.deepEqual(ast, {
+      "type": "FunctionDefinition",
+      "name": "foo",
+      "parameters": [],
+      "returnParameters": null,
+      "body": {
+        "type": "Block",
+        "statements": []
+      },
+      "visibility": "public",
+      "modifiers": [],
+      "override": [],
+      "isConstructor": false,
+      "isFallback": false,
+      "isReceiveEther": false,
+      "isVirtual": false,
+      "stateMutability": null,
+    })
+  })
+
+  it('FunctionDefinition with one explicit override', () => {
+    var ast = parseNode("function foo() public override(Base) {}")
+    assert.deepEqual(ast, {
+      "type": "FunctionDefinition",
+      "name": "foo",
+      "parameters": [],
+      "returnParameters": null,
+      "body": {
+        "type": "Block",
+        "statements": []
+      },
+      "visibility": "public",
+      "modifiers": [],
+      "override": [{
+        "type": "UserDefinedTypeName",
+        "namePath": "Base"
+      }],
+      "isConstructor": false,
+      "isFallback": false,
+      "isReceiveEther": false,
+      "isVirtual": false,
+      "stateMutability": null,
+    })
+  })
+
+  it('FunctionDefinition with two overrides', () => {
+    var ast = parseNode("function foo() public override(Base1, Base2) {}")
+    assert.deepEqual(ast, {
+      "type": "FunctionDefinition",
+      "name": "foo",
+      "parameters": [],
+      "returnParameters": null,
+      "body": {
+        "type": "Block",
+        "statements": []
+      },
+      "visibility": "public",
+      "modifiers": [],
+      "override": [{
+        "type": "UserDefinedTypeName",
+        "namePath": "Base1"
+      }, {
+        "type": "UserDefinedTypeName",
+        "namePath": "Base2"
+      }],
+      "isConstructor": false,
+      "isFallback": false,
+      "isReceiveEther": false,
+      "isVirtual": false,
+      "stateMutability": null,
+    })
+  })
+
   it("FunctionDefinition", function() {
     var ast = parseNode("function foo(uint a) pure {}")
     assert.deepEqual(ast, {
@@ -311,6 +390,7 @@ describe('AST', () => {
       },
       "visibility": "default",
       "modifiers": [],
+      "override": null,
       "isConstructor": false,
       "isFallback": false,
       "isReceiveEther": false,
@@ -330,6 +410,7 @@ describe('AST', () => {
       },
       "visibility": "public",
       "modifiers": [],
+      "override": null,
       "isConstructor": false,
       "isFallback": false,
       "isReceiveEther": false,
@@ -374,6 +455,7 @@ describe('AST', () => {
       },
       "visibility": "default",
       "modifiers": [],
+      "override": null,
       "isConstructor": false,
       "isFallback": false,
       "isReceiveEther": false,


### PR DESCRIPTION
This adds some failing tests for functions that use the `override` keyword. See the expected value for the proposed structure of the AST for this nodes.